### PR TITLE
examples: fetch examples for monad and spacetime

### DIFF
--- a/examples/fetch/example-monad.ts
+++ b/examples/fetch/example-monad.ts
@@ -1,0 +1,18 @@
+async function getEthBlockNumber(url: string) {
+	const response = await fetch(url, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'eth_blockNumber',
+			params: []
+		})
+	})
+	const data = await response.json()
+	const blockNumber = parseInt(data.result, 16)
+	console.log(`Latest block: ${blockNumber} (0x${data.result})`)
+}
+
+// Get latest block number from Monad testnet
+getEthBlockNumber("https://rpc.ankr.com/monad_testnet").catch(console.error)

--- a/examples/fetch/example-space-time.ts
+++ b/examples/fetch/example-space-time.ts
@@ -1,0 +1,56 @@
+const CONFIG = {
+	baseUrl: 'https://proxy.api.makeinfinite.dev',
+	apiKey: '<INSERT_API_KEY>',
+	password: 'this_is_password_for_above_user_in_the_worker'
+}
+
+const randomPrefix = () => 
+	Array.from({ length: 4 }, () => 
+		String.fromCharCode(97 + Math.floor(Math.random() * 26))
+	).join('')
+
+async function main() {
+	try {
+		const userId = `${randomPrefix()}_your_username_here`
+
+		const authResponse = await fetch(`${CONFIG.baseUrl}/auth/register`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Accept: 'application/json'
+			},
+			body: JSON.stringify({ userId, password: CONFIG.password })
+		})
+
+		if (!authResponse.ok) {
+			throw new Error(`Auth failed: ${await authResponse.text()}`)
+		}
+
+		const { accessToken } = await authResponse.json()
+		console.log('Auth success')
+
+		const queryResponse = await fetch(`${CONFIG.baseUrl}/v1/sql`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Accept: 'application/json',
+				Authorization: `Bearer ${accessToken}`,
+				apikey: CONFIG.apiKey
+			},
+			body: JSON.stringify({
+				sqlText: 'SELECT * FROM bitcoin.transactions LIMIT 5'
+			})
+		})
+
+		if (!queryResponse.ok) {
+			throw new Error(`Query failed: ${await queryResponse.text()}`)
+		}
+
+		const queryResult = await queryResponse.json()
+		console.log('Query result:\n', JSON.stringify(queryResult, null, 2))
+	} catch (error) {
+		console.error('Error:', error)
+	}
+}
+
+main()


### PR DESCRIPTION
## Description

This pull request adds two new example scripts demonstrating the use of `fetch` for interacting with external APIs.
The examples include: 
- fetching the latest block number from `Monad` testnet
- executing SQL queries on a Bitcoin transaction database using a proxy API of SpacetimeDB

### Examples for API interactions:

* [`examples/fetch/example-monad.ts`](diffhunk://#diff-7682439398483a1cc1d0a4826ee1a27f7340b3c7a8039d98652419ae78a7b9baR1-R18): Added a script to fetch the latest Ethereum block number from the Monad testnet using JSON-RPC. The script parses the hexadecimal block number and logs it in both decimal and hexadecimal formats.

* [`examples/fetch/example-space-time.ts`](diffhunk://#diff-62e178e0cb35e6ad59ed43844e91d828d147c19c6ba06310e99c4e4161950bc1R1-R56): Added a script to interact with a proxy API for SQL queries. The script includes user registration for authentication, obtaining an access token, and executing a SQL query to retrieve Bitcoin transaction data. It logs the query results in a formatted JSON structure.